### PR TITLE
chore: skip SDD check

### DIFF
--- a/.vtex/catalog-info.yaml
+++ b/.vtex/catalog-info.yaml
@@ -13,6 +13,8 @@ metadata:
     backstage.io/techdocs-ref: dir:../
     vtex.com/application-id: 7U64UVH4
     vtex.com/platform-flow-id: CommDev#1
+    vtex.com/sdd-check-skip: 'true'
+    vtex.com/sdd-check-skip-reason: Auxiliar project for just homebrew updates
 spec:
   lifecycle: stable
   owner: te-0029


### PR DESCRIPTION
Add `vtex.com/sdd-check-skip` and `vtex.com/sdd-check-skip-reason` annotations to skip the SDD check for this repository.

**Reason:** Auxiliar project for just homebrew updates