### PR TITLE
Update brew tap to 4.4.2

### DIFF
--- a/Formula/vtex.rb
+++ b/Formula/vtex.rb
@@ -1,9 +1,9 @@
 class Vtex < Formula
   desc "CLI tool for creating and managing VTEX apps"
   homepage "https://github.com/vtex/toolbelt"
-  url "https://vtex-toolbelt-test.s3.amazonaws.com/vtex-v4.4.1/vtex-v4.4.1-darwin-x64.tar.gz"
-  version "4.4.1"
-  sha256 "2bb7ac2eab8b191820afcb1728fe25112538e5b6799956cb79062ee9432372b8"
+  url "https://vtex-toolbelt-test.s3.amazonaws.com/vtex-v4.4.2/vtex-v4.4.2-darwin-x64.tar.gz"
+  version "4.4.2"
+  sha256 "e1eb9a38db21572004351470094fd6d07d2333d48a2fccb5ddf5e0adc1a22fd5"
 
   def install
     inreplace "bin/vtex", /^CLIENT_HOME=/, "export VTEX_OCLIF_CLIENT_HOME=#{lib/"client"}\nCLIENT_HOME="


### PR DESCRIPTION
Manual brew formula bump to 4.4.2 (toolbelt's automated dispatch failed on an expired token).